### PR TITLE
addresses https://github.com/ubtue/DatenProbleme/issues/2076 and https://github.com/ubtue/Datenprobleme/issues/2082

### DIFF
--- a/ubtue_Harrassowitz_Deutsches_Archiv_fuer_Erforschung_des_Mittelalters.js
+++ b/ubtue_Harrassowitz_Deutsches_Archiv_fuer_Erforschung_des_Mittelalters.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-03-20 16:00:48"
+	"lastUpdated": "2024-03-27 15:48:56"
 }
 
 /*
@@ -37,7 +37,6 @@
 
 
 function detectWeb(doc, url) {
-	// TODO: adjust the logic here
 	if (url.includes('/article/')) {
 		return 'journalArticle';
 	}

--- a/ubtue_Harrassowitz_Deutsches_Archiv_fuer_Erforschung_des_Mittelalters.js
+++ b/ubtue_Harrassowitz_Deutsches_Archiv_fuer_Erforschung_des_Mittelalters.js
@@ -1,0 +1,139 @@
+{
+	"translatorID": "b38357c5-9b3b-4254-8643-829727fd06ea",
+	"label": "ubtue_Harrassowitz_Deutsches_Archiv_fuer_Erforschung_des_Mittelalters",
+	"creator": "Mara Spieß",
+	"target": "https://mgh-da.harrassowitz-library.com/(issue|article)",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2024-03-20 16:00:48"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2022 YOUR_NAME <- TODO
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	// TODO: adjust the logic here
+	if (url.includes('/article/')) {
+		return 'journalArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('.title');
+	for (let row of rows) {
+		let anchor = row.querySelector('a');
+		let href = anchor ? anchor.getAttribute('href') : null;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+	
+	translator.setHandler('itemDone', (_obj, item) => {
+		item.title = item.title.replace(/<\/?(?:[^>]+)>/g, '');
+		if (item.title.match(/^\d+[.]\s*/))
+			 item.tags.push('RezensionstagPica');
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+	{
+		"type": "web",
+		"url": "https://mgh-da.harrassowitz-library.com/article/MGH-DA/2023/1/3",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Zur Entstehung der „Kapitulariensammlung“ im Liber legum des Lupus und zur Vielfalt der „Kapitularien“ Karls des Großen",
+				"creators": [
+					{
+						"firstName": "Takuro",
+						"lastName": "Tsuda",
+						"creatorType": "author"
+					}
+				],
+				"date": "2023",
+				"DOI": "10.13173/MGH-DA.79.1.001",
+				"ISSN": "21943842",
+				"issue": "1",
+				"language": "de",
+				"libraryCatalog": "mgh-da.harrassowitz-library.com",
+				"pages": "1-71",
+				"publicationTitle": "Deutsches Archiv für Erforschung des Mittelalters",
+				"url": "https://mgh-da.harrassowitz-library.com/article/MGH-DA/2023/1/3",
+				"volume": "79",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	}
+]
+/** END TEST CASES **/

--- a/ubtue_Oxford Academic.js
+++ b/ubtue_Oxford Academic.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-08-16 15:43:33"
+	"lastUpdated": "2024-03-04 15:55:54"
 }
 
 /*
@@ -93,6 +93,9 @@ function invokeEmbeddedMetadataTranslator(doc, url) {
 				i.date = ZU.xpathText(doc, '//div[contains(@class, "pub-date")]').match(/\d{4}/)[0];
 			}
 		}
+		if (ZU.xpathText(doc, '//div[@class="ww-citation-primary"]/a')) {
+			i.url = ZU.xpathText(doc, '//div[@class="ww-citation-primary"]/a')
+		}
 		i.complete();
 	});
 	translator.translate();
@@ -113,6 +116,7 @@ function doWeb(doc, url) {
 	} else
 		invokeEmbeddedMetadataTranslator(doc, url);
 }
+
 
 
 /** BEGIN TEST CASES **/
@@ -159,6 +163,83 @@ var testCases = [
 					}
 				],
 				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://academic.oup.com/ijtj/issue/17/2",
+		"items": "multiple"
+	},
+	{
+		"type": "web",
+		"url": "https://academic.oup.com/bjc/article/64/2/257/7222129",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Confronting intergenerational harm: Care experience, motherhood and criminal justice involvement",
+				"creators": [
+					{
+						"firstName": "Claire",
+						"lastName": "Fitzpatrick",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Katie",
+						"lastName": "Hunter",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Julie",
+						"lastName": "Shaw",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Jo",
+						"lastName": "Staines",
+						"creatorType": "author"
+					}
+				],
+				"date": "2024",
+				"DOI": "10.1093/bjc/azad028",
+				"ISSN": "0007-0955",
+				"abstractNote": "Prior research highlights how criminalized mothers may be particularly at risk of negative judgements, but little work to date explores how criminalisation, care experience and motherhood may intersect to produce multi-faceted structural disadvantage within both systems of care and punishment. This paper attends to this knowledge gap, drawing on interviews with imprisoned women who have been in care (e.g. foster care or children’s homes), care-experienced girls and young women in the community, and professionals who work with them. Key findings include: a desire to break cycles of intergenerational stigma and social care involvement; lack of support and a fear of asking for help, and the care-less approach to pregnancy and motherhood that may be faced in prison and beyond.",
+				"issue": "2",
+				"journalAbbreviation": "Br J Criminol",
+				"language": "en",
+				"libraryCatalog": "academic.oup.com",
+				"pages": "257-274",
+				"publicationTitle": "The British Journal of Criminology",
+				"shortTitle": "Confronting intergenerational harm",
+				"url": "https://doi.org/10.1093/bjc/azad028",
+				"volume": "64",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [
+					"LF:",
+					{
+						"note": "orcid:0000-0003-4662-2342 | Claire Fitzpatrick"
+					},
+					{
+						"note": "orcid:0000-0001-7811-5666 | Katie Hunter"
+					},
+					{
+						"note": "orcid:0000-0002-0192-178X | Julie Shaw"
+					},
+					{
+						"note": "orcid:0000-0001-7285-496X | Jo Staines"
+					}
+				],
 				"seeAlso": []
 			}
 		]

--- a/ubtue_Oxford Academic.js
+++ b/ubtue_Oxford Academic.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2022-08-16 15:43:33"
+	"lastUpdated": "2024-03-22 14:15:51"
 }
 
 /*
@@ -93,6 +93,7 @@ function invokeEmbeddedMetadataTranslator(doc, url) {
 				i.date = ZU.xpathText(doc, '//div[contains(@class, "pub-date")]').match(/\d{4}/)[0];
 			}
 		}
+		i.url = i.url.match(/dx.doi.org/) && i.DOI ? "" : i.url;
 		i.complete();
 	});
 	translator.translate();
@@ -113,6 +114,7 @@ function doWeb(doc, url) {
 	} else
 		invokeEmbeddedMetadataTranslator(doc, url);
 }
+
 
 
 /** BEGIN TEST CASES **/

--- a/ubtue_Oxford Academic.js
+++ b/ubtue_Oxford Academic.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-03-22 14:15:51"
+	"lastUpdated": "2024-03-22 14:46:16"
 }
 
 /*
@@ -161,6 +161,105 @@ var testCases = [
 					}
 				],
 				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://academic.oup.com/bjc/article/64/2/275/7226326",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Rescuing women from the brinks of whiteness: Carceral restoration in a human trafficking court",
+				"creators": [
+					{
+						"firstName": "Rashmee",
+						"lastName": "Singh",
+						"creatorType": "author"
+					}
+				],
+				"date": "2024",
+				"DOI": "10.1093/bjc/azad030",
+				"ISSN": "0007-0955",
+				"abstractNote": "Research on gender-specific penal reform programs critique their failure to prioritize the socio-economic recovery of criminalized women. This paper draws on these insights to examine the Women’s Refuge Court (WRC), a human trafficking court for adult women criminalized for prostitution and drug offences in Ohio. Using ethnographic research, I illustrate the WRC’s rejection of bootstrapping and emphasis on material resourcing as a penal reform strategy. I argue that the WRC’s prioritization of socio-economic recovery derives from fears over the status decline of the impoverished white women who predominate as defendants. Court officials rely on evangelical Christian imaginings of prostitution as ‘modern day slavery’ to frame participants as ‘trafficking victims’. I identify the WRC’s response as a racially specific form of gender responsive programming called carceral restoration.",
+				"issue": "2",
+				"journalAbbreviation": "Br J Criminol",
+				"language": "en",
+				"libraryCatalog": "academic.oup.com",
+				"pages": "275-291",
+				"publicationTitle": "The British Journal of Criminology",
+				"shortTitle": "Rescuing women from the brinks of whiteness",
+				"volume": "64",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [],
+				"seeAlso": []
+			}
+		]
+	},
+	{
+		"type": "web",
+		"url": "https://academic.oup.com/ijtj/article/17/2/192/7174226",
+		"items": [
+			{
+				"itemType": "journalArticle",
+				"title": "Between Impunity and Justice? Exploring Stakeholders’ Perceptions of Colombia’s Special Sanctions (Sanciones Propias) for International Crimes",
+				"creators": [
+					{
+						"firstName": "Beatriz E.",
+						"lastName": "Mayans-Hermida",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Barbora",
+						"lastName": "Holá",
+						"creatorType": "author"
+					},
+					{
+						"firstName": "Catrien",
+						"lastName": "Bijleveld",
+						"creatorType": "author"
+					}
+				],
+				"date": "2023",
+				"DOI": "10.1093/ijtj/ijad009",
+				"ISSN": "1752-7716",
+				"abstractNote": "The peace agreement signed by the Colombian government and the FARC has an innovative sanctioning regime which, based on a restorative approach, offers non-custodial sanctions as a less punitive form of punishment for international crimes. However, given their leniency, these ‘special sanctions’ have caused controversy. Based on qualitative interviews, this study explores the perceptions of different stakeholders concerning various issues related to the special sanctions’ nature, goals, processes, (envisioned) outcomes and challenges. Our findings reveal that most participants perceive these sanctions as a tool that can modestly help repair the damage done, reintegrate (certain) offenders into society, and promote coexistence. Only a limited number of respondents saw these sanctions as punishment. For several participants, the special sanctions may be an alternative accountability measure to prison. However, this seems to depend on meeting certain preconditions, victims’ participation, the type of crime and the offender’s rank and affiliation.",
+				"issue": "2",
+				"journalAbbreviation": "Int J Transit Justice",
+				"language": "en",
+				"libraryCatalog": "academic.oup.com",
+				"pages": "192-211",
+				"publicationTitle": "International Journal of Transitional Justice",
+				"shortTitle": "Between Impunity and Justice?",
+				"volume": "17",
+				"attachments": [
+					{
+						"title": "Full Text PDF",
+						"mimeType": "application/pdf"
+					},
+					{
+						"title": "Snapshot",
+						"mimeType": "text/html"
+					}
+				],
+				"tags": [],
+				"notes": [
+					"LF:",
+					{
+						"note": "orcid:0000-0002-4241-0038 | Beatriz E Mayans-Hermida"
+					}
+				],
 				"seeAlso": []
 			}
 		]

--- a/ubtue_Oxford Academic.js
+++ b/ubtue_Oxford Academic.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-03-04 15:55:54"
+	"lastUpdated": "2022-08-16 15:43:33"
 }
 
 /*
@@ -93,9 +93,6 @@ function invokeEmbeddedMetadataTranslator(doc, url) {
 				i.date = ZU.xpathText(doc, '//div[contains(@class, "pub-date")]').match(/\d{4}/)[0];
 			}
 		}
-		if (ZU.xpathText(doc, '//div[@class="ww-citation-primary"]/a')) {
-			i.url = ZU.xpathText(doc, '//div[@class="ww-citation-primary"]/a')
-		}
 		i.complete();
 	});
 	translator.translate();
@@ -116,7 +113,6 @@ function doWeb(doc, url) {
 	} else
 		invokeEmbeddedMetadataTranslator(doc, url);
 }
-
 
 
 /** BEGIN TEST CASES **/
@@ -163,83 +159,6 @@ var testCases = [
 					}
 				],
 				"notes": [],
-				"seeAlso": []
-			}
-		]
-	},
-	{
-		"type": "web",
-		"url": "https://academic.oup.com/ijtj/issue/17/2",
-		"items": "multiple"
-	},
-	{
-		"type": "web",
-		"url": "https://academic.oup.com/bjc/article/64/2/257/7222129",
-		"items": [
-			{
-				"itemType": "journalArticle",
-				"title": "Confronting intergenerational harm: Care experience, motherhood and criminal justice involvement",
-				"creators": [
-					{
-						"firstName": "Claire",
-						"lastName": "Fitzpatrick",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Katie",
-						"lastName": "Hunter",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Julie",
-						"lastName": "Shaw",
-						"creatorType": "author"
-					},
-					{
-						"firstName": "Jo",
-						"lastName": "Staines",
-						"creatorType": "author"
-					}
-				],
-				"date": "2024",
-				"DOI": "10.1093/bjc/azad028",
-				"ISSN": "0007-0955",
-				"abstractNote": "Prior research highlights how criminalized mothers may be particularly at risk of negative judgements, but little work to date explores how criminalisation, care experience and motherhood may intersect to produce multi-faceted structural disadvantage within both systems of care and punishment. This paper attends to this knowledge gap, drawing on interviews with imprisoned women who have been in care (e.g. foster care or children’s homes), care-experienced girls and young women in the community, and professionals who work with them. Key findings include: a desire to break cycles of intergenerational stigma and social care involvement; lack of support and a fear of asking for help, and the care-less approach to pregnancy and motherhood that may be faced in prison and beyond.",
-				"issue": "2",
-				"journalAbbreviation": "Br J Criminol",
-				"language": "en",
-				"libraryCatalog": "academic.oup.com",
-				"pages": "257-274",
-				"publicationTitle": "The British Journal of Criminology",
-				"shortTitle": "Confronting intergenerational harm",
-				"url": "https://doi.org/10.1093/bjc/azad028",
-				"volume": "64",
-				"attachments": [
-					{
-						"title": "Full Text PDF",
-						"mimeType": "application/pdf"
-					},
-					{
-						"title": "Snapshot",
-						"mimeType": "text/html"
-					}
-				],
-				"tags": [],
-				"notes": [
-					"LF:",
-					{
-						"note": "orcid:0000-0003-4662-2342 | Claire Fitzpatrick"
-					},
-					{
-						"note": "orcid:0000-0001-7811-5666 | Katie Hunter"
-					},
-					{
-						"note": "orcid:0000-0002-0192-178X | Julie Shaw"
-					},
-					{
-						"note": "orcid:0000-0001-7285-496X | Jo Staines"
-					}
-				],
 				"seeAlso": []
 			}
 		]


### PR DESCRIPTION
Standardmäßig übernimmt der Translator eine "veraltete" DOI, die vom Verlag noch im DOM angegeben wird, diese hab ich mit der korrekten Version aus der Quellenangabe ersetzt. 