### PR TITLE
addresses https://github.com/ubtue/DatenProbleme/issues/2227

### DIFF
--- a/ubtue_Ashland_Theological_Journal.js
+++ b/ubtue_Ashland_Theological_Journal.js
@@ -1,0 +1,101 @@
+{
+	"translatorID": "bbeefac5-f247-4e3e-b62c-2a61100542ef",
+	"label": "ubtue_Ashland_Theological_Journal",
+	"creator": "Mara Spieß",
+	"target": "https://biblicalstudies.org.uk/articles_ashland-theological-journal",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-02-19 09:26:09"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2025 Universitätsbibliothek Tübingen
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.includes('/articles')) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a[href*="pdf/ashland_theological_journal"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getAuthor(author, item) {
+	author = ZU.cleanAuthor(author, 'author', false);
+	item.creators.push(author);
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			let item = new Zotero.Item("journalArticle");
+			item.publicationTitle = "Ashland Theological Journal";
+			item.ISSN = "1044-6494";
+			item.url = url;
+			let relativeUrl = new URL(url);
+			let entry = doc.querySelector('a[href*="' + relativeUrl.pathname.replace("/pdf/", "pdf/") + '"]');
+			if (entry) {
+				let entryText = entry.textContent;
+				let citation = entryText.match(/(.*),?\s*"([\s\S]*),?"\s+ashland theological journal\s+(\d+)\.(\d+)\s+\(\w+\s+(\d+)\):\s(\d+-\d+)/i);
+				if (citation) {
+					if (citation[1].length) {
+						let authors = citation[1].replace('et al', '').split('&');
+						authors.forEach(author => getAuthor(author, item));
+					}
+					item.title = citation[2];
+					item.volume = citation[3];
+					item.issue = citation[4];
+					item.date = citation[5];
+					item.pages = citation[6];	
+				}
+			}
+
+			item.complete();
+		}
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/ubtue_BMJ_Journals.js
+++ b/ubtue_BMJ_Journals.js
@@ -1,0 +1,119 @@
+{
+	"translatorID": "17809ade-c31b-40e5-b627-528235a8dd1d",
+	"label": "ubtue_BMJ_Journals",
+	"creator": "Mara Spieß",
+	"target": "https://jme.bmj.com/content/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-02-18 11:45:48"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2025 Unibibliothek Tübingen
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.match(/content\/\d*\/\d*\/d*/)) {
+		return 'journalArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a.highwire-cite-linked-title[href*="/content/"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+function extractOrcids(doc, item) {
+	for (orcid_tag of ZU.xpath(doc, '//meta[@name="citation_author_orcid"]')){
+		let previous_author_tag = orcid_tag.previousElementSibling;
+		while (previous_author_tag && previous_author_tag.name !== "citation_author") {
+			previous_author_tag = previous_author_tag.previousElementSibling;
+		}
+		if (previous_author_tag && previous_author_tag.name === "citation_author") {
+			let author_name = previous_author_tag.content;
+			let orcid = orcid_tag.content.match(/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]/i);
+			item.notes.push({note: "orcid:" + orcid[0] + ' | ' + author_name + ' | ' + "taken from website"});
+		}
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+	
+	translator.setHandler('itemDone', (_obj, item) => {
+
+		item.abstractNote = ZU.cleanTags(item.abstractNote);
+
+		let accessRights = doc.querySelector('meta[name="DC.AccessRights"]');
+		if (accessRights && accessRights.getAttribute('content').match(/open-access/i)) {
+			item.notes.push("LF:");
+		}
+
+		extractOrcids(doc, item);
+		
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/ubtue_Crime_and_Justice.js
+++ b/ubtue_Crime_and_Justice.js
@@ -2,14 +2,14 @@
 	"translatorID": "dec09eec-baee-44d3-a306-5dfb8d3ae733",
 	"label": "ubtue_Crime_and_Justice",
 	"creator": "Mara Spieß",
-	"target": "https://www.crimeandjustice.org.uk/publications",
+	"target": "https://www.crimeandjustice.org.uk/",
 	"minVersion": "5.0",
 	"maxVersion": "",
 	"priority": 100,
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-09-16 12:15:40"
+	"lastUpdated": "2025-02-19 09:50:33"
 }
 
 /*
@@ -37,7 +37,7 @@
 
 
 function detectWeb(doc, url) {
-	if (url.includes('/psj/')) {
+	if (url.includes('/prison-service-journal')) {
 		return 'multiple';
 	}
 	return false;
@@ -61,13 +61,13 @@ function getSearchResults(doc, checkOnly) {
 function getAuthors(entry) {
 	titleEntry = entry.closest('li');
 	titleEntry.removeChild(entry);
-	strippedPrefix = titleEntry.textContent.replace(/(?:\s*,\s*)?(?:(interviewe?d?|reviewed)\s+)?by\s*/ig, '').replace(/(?:\s*Dr\s+)|(?:\s*Professor\s+)/g, '');
+	strippedPrefix = titleEntry.textContent.replace(/(?:\s*,\s*)?(?:(interviewe?d?|reviewed)\s+)?by\b\s*/ig, '').replace(/(?:\s*Dr\s+)|(?:\s*Professor\s+)/g, '');
 	authors = strippedPrefix.split(/and\s+|[,]/);
 return authors;
 }
 
 function getVolume(doc, item) {
-	let volumeNumber = doc.querySelector('h1.node-header');
+	let volumeNumber = doc.querySelector('span.field--name-title');
 	if (volumeNumber) {
 		let volumeNumberMatch = volumeNumber.innerText.match(/prison\s+service\s+journal\s+(\d+)/i);
 		if (volumeNumberMatch) {
@@ -77,9 +77,9 @@ function getVolume(doc, item) {
 }
 
 function getDate(doc, item) {
-	let date = doc.querySelector('span.date-display-single');
+	let date = doc.querySelector('div.field--name-field-date');
 	if (date) {
-		let dateMatch = date.innerText.match(/\w+,\s+\d+\s\w+\s+(\d+)/i);
+		let dateMatch = date.innerText.match(/\d+\s+\w+\s+(\d+)/i);
 		if (dateMatch) {
 			item.date = dateMatch[1];
 		}

--- a/ubtue_Indian_Journal_Criminology.js
+++ b/ubtue_Indian_Journal_Criminology.js
@@ -1,0 +1,104 @@
+{
+	"translatorID": "ba37e957-a0bd-4bb9-9c81-f33eb661480f",
+	"label": "ubtue_Indian_Journal_Criminology",
+	"creator": "Mara Spieß",
+	"target": "https://sites.google.com/view/ijc-archive",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2025-02-19 13:12:08"
+}
+
+/*
+	***** BEGIN LICENSE BLOCK *****
+
+	Copyright © 2025 Universitätsbibliothek Tübingen
+
+	This file is part of Zotero.
+
+	Zotero is free software: you can redistribute it and/or modify
+	it under the terms of the GNU Affero General Public License as published by
+	the Free Software Foundation, either version 3 of the License, or
+	(at your option) any later version.
+
+	Zotero is distributed in the hope that it will be useful,
+	but WITHOUT ANY WARRANTY; without even the implied warranty of
+	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+	GNU Affero General Public License for more details.
+
+	You should have received a copy of the GNU Affero General Public License
+	along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+	***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.includes('/ijc-archive-article')) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('a.XqQF9c[href*="/file/"]');
+	for (let row of rows) {
+		let href = row.href;
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+function getAuthor (author, item) {
+	author = ZU.cleanAuthor(author, 'author', false);
+	item.creators.push(author);
+}
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			let item = new Zotero.Item("journalArticle");
+			item.ISSN = "0974-7249";
+			item.url = url;
+			var relativeUrl = new URL(url);
+			entry = doc.querySelector('a[href*="' + relativeUrl.pathname + '"]');
+			item.title = entry.textContent;
+
+			let citationElement = ZU.xpathText(doc, '//span[contains(@class, "C9DxTc ")][contains(text(), "Vol.")]');
+			if (citationElement) {
+				let citationMatch = citationElement.match(/(\d{4})\s+vol.\s(\d+)(\s+\((\d+)\))?/i);
+				if (citationMatch) {
+					item.date = citationMatch[1].length ? citationMatch[1] : "";
+					item.volume = citationMatch[2].length ? citationMatch[2] : "";
+					item.issue = citationMatch[3].length ? citationMatch[3].replace(/\(|\)/g, '') : "";
+				}
+			}
+
+			let authorElement = entry.nextElementSibling;
+			while (!authorElement) {
+				authorElement = entry.parentNode.nextElementSibling;
+			}
+			if (authorElement) {
+				let authors = authorElement.textContent.replace(/mrs\b|mr\b/ig, '').split(/and\b|,/);
+				authors.forEach(author => getAuthor(author, item));
+			}
+			
+			item.complete();
+		}
+	}
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/ubtue_Open Journal Systems Standard.js
+++ b/ubtue_Open Journal Systems Standard.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-02-13 10:37:34"
+	"lastUpdated": "2025-02-13 16:20:32"
 }
 
 /*
@@ -209,6 +209,28 @@ function invokeEMTranslator(doc) {
 						for (let match of matches) {
 							let author = match.match(/<strong>(.+?)<\/strong>/)[1];
 							let orcid = match.match(/<a href="https?:\/\/orcid.org\/(.+?)" target="_blank">/)[1];
+							addNote(orcid, author);
+						}
+					}
+				}
+			}
+		}
+
+		if (orcidAuthorEntryCaseA.length && ['2813-4613'].includes(i.ISSN)) {
+			for (let entry of orcidAuthorEntryCaseA) {
+				let orcidElements = entry.querySelectorAll('span.orcid');
+				for (let orcidTag of orcidElements) {
+					let orcidLink = orcidTag.querySelector('a[href^="http://orcid.org/"]');
+					if (orcidLink) {
+						let orcid = orcidLink.innerText.match(/\d+-\d+-\d+-\d+x?/i)[0];
+						let previousElement = orcidTag.previousElementSibling;
+						let author = null;
+						if (previousElement) {
+							if (previousElement.tagName.toLowerCase() === 'strong') {
+								author = previousElement.textContent.trim();
+							}
+						}
+						if (orcid && author) {
 							addNote(orcid, author);
 						}
 					}

--- a/ubtue_Open Journal Systems Standard.js
+++ b/ubtue_Open Journal Systems Standard.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-02-13 16:20:32"
+	"lastUpdated": "2025-02-21 13:12:49"
 }
 
 /*
@@ -764,6 +764,12 @@ function invokeEMTranslator(doc) {
 				creator.lastName.toLowerCase() === "editor")
 				));
 			if (!doc.querySelector('a.pdf.restricted')) {
+				i.notes.push('LF:');
+			}
+		}
+
+		if (['1749-4915'].includes(i.ISSN)) {
+			if (ZU.xpath(doc, '//a[contains(@class, "pdf") and contains(text(), "OPEN ACCESS")]').length > 0) {
 				i.notes.push('LF:');
 			}
 		}

--- a/ubtue_Rivisteweb.js
+++ b/ubtue_Rivisteweb.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-02-12 14:31:28"
+	"lastUpdated": "2025-02-18 11:59:42"
 }
 
 /*
@@ -126,17 +126,17 @@ function cleanTags(tags) {
 }
 
 function getOrcids(doc, item) {
-    let authors = doc.querySelectorAll('p.authors > a.author');
-    authors.forEach(author => {
-        let authorName = author.textContent.trim();
-        let orcidElement = author.querySelector('i.bi-rw-orcid');
-        if (orcidElement) {
-            let orcid = orcidElement.getAttribute('title').match(/\d{4}-\d{4}-\d{4}-\d{4}/);
-            if (orcid) {
-                item.notes.push("orcid: " + orcid[0] + ' | ' + authorName + ' | ' + 'taken from website');
-            }
-        }
-    });
+	let authors = doc.querySelectorAll('p.authors > a.author');
+	authors.forEach(author => {
+		let authorName = author.textContent.trim();
+		let orcidElement = author.querySelector('i.bi-rw-orcid');
+		if (orcidElement) {
+			let orcid = orcidElement.getAttribute('title').match(/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]/i);
+			if (orcid) {
+				item.notes.push("orcid: " + orcid[0] + ' | ' + authorName + ' | ' + 'taken from website');
+			}
+		}
+	});
 }
 
 function scrape(doc, url) {

--- a/ubtue_Taylor and Francis+NEJM.js
+++ b/ubtue_Taylor and Francis+NEJM.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-01-07 08:57:29"
+	"lastUpdated": "2025-02-18 14:20:15"
 }
 
 /*
@@ -152,7 +152,10 @@ function scrape(doc, url) {
 					}
 					//ubtue:adding subtitle
 					let subtitle = ZU.xpathText(doc, '//*[@class="NLM_subtitle"]');
-					if (subtitle && subtitle.length) item.title += ': ' + subtitle;
+					if (!subtitle)
+					    subtitle = ZU.xpathText(doc, '//*[@class="sub-title"]');
+                    if (subtitle)
+					    item.title += ': ' + subtitle;
 					//ubtue:item.creators retrieved from ris, because bibtex is adding some unuseful "names"
 					//e.g. corporate bodies "Bill Gaventa and National Collaborative on Faith and Disability, with" https://doi.org/10.1080/23312521.2020.1743223
 					//or title like "Rev." https://www.tandfonline.com/doi/full/10.1080/23312521.2020.1738627

--- a/ubtue_Zygon.js
+++ b/ubtue_Zygon.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2024-12-12 14:48:56"
+	"lastUpdated": "2025-02-18 09:57:27"
 }
 
 /*
@@ -75,6 +75,24 @@ async function doWeb(doc, url) {
 	}
 }
 
+function extractOrcid(doc, item) {
+	for (orcid_tag of ZU.xpath(doc, '//meta[@name="citation_author_orcid"]')){
+		let previous_author_tag = orcid_tag.previousElementSibling;
+		if (previous_author_tag.name == 'citation_author') {
+			let author_name = previous_author_tag.content;
+			let orcid = orcid_tag.content;
+			item.notes.push({note: "orcid:" + orcid + ' | ' + author_name + ' | ' + "taken from website"});
+		}
+	}
+	if (!item.notes.some(obj => obj.note.startsWith('orcid'))) {
+		for (orcid_element of ZU.xpath(doc, '//a[contains(@href, "orcid")]')) {
+			let orcid = orcid_element.href.match(/\d{4}-\d{4}-\d{4}-\d{4}/);
+			let author_name = orcid_element.previousSibling.textContent.trim()
+			item.notes.push({note: "orcid:" + orcid[0] + ' | ' + author_name + ' | ' + "taken from website"});
+		}
+	}
+}
+
 async function scrape(doc, url = doc.location.href) {
 	let translator = Zotero.loadTranslator('web');
 	// Embedded Metadata
@@ -82,7 +100,7 @@ async function scrape(doc, url = doc.location.href) {
 	translator.setDocument(doc);
 
 	translator.setHandler('itemDone', (_obj, item) => {
-		if (item.abstractNote.length < 20) {
+		if (item.abstractNote?.length < 20) {
 			let abstractNEU = text(doc, 'div.card-content h2~p'); 
 			if (abstractNEU.length > 20) {
 				item.abstractNote = abstractNEU; 
@@ -91,14 +109,8 @@ async function scrape(doc, url = doc.location.href) {
 				item.abstractNote = "";
 			}
 		}
-		for (orcid_tag of ZU.xpath(doc, '//meta[@name="citation_author_orcid"]')){
-			let previous_author_tag = orcid_tag.previousElementSibling;
-			if (previous_author_tag.name == 'citation_author') {
-				let author_name = previous_author_tag.content;
-				let orcid = orcid_tag.content;
-				item.notes.push({note: "orcid:" + orcid + ' | ' + author_name + ' | ' + " taken from website"});
-			}
-		}
+
+		extractOrcid(doc, item);
 			
 		if (text(doc, 'span.card-title div small') == 'Reviews'){
 			item.tags.push("RezensionstagPica");
@@ -107,6 +119,7 @@ async function scrape(doc, url = doc.location.href) {
 		if (!item.pages && ZU.xpathText(doc, '//th[text()="Pages"]/following-sibling::td/text()')) item.pages = ZU.xpathText(doc, '//th[text()="Pages"]/following-sibling::td/text()');
 
 		item.complete();
+
 	});
 
 	

--- a/ubtue_Zygon.js
+++ b/ubtue_Zygon.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2025-02-18 09:57:27"
+	"lastUpdated": "2025-02-18 11:23:45"
 }
 
 /*
@@ -86,7 +86,7 @@ function extractOrcid(doc, item) {
 	}
 	if (!item.notes.some(obj => obj.note.startsWith('orcid'))) {
 		for (orcid_element of ZU.xpath(doc, '//a[contains(@href, "orcid")]')) {
-			let orcid = orcid_element.href.match(/\d{4}-\d{4}-\d{4}-\d{4}/);
+			let orcid = orcid_element.href.match(/\d{4}-\d{4}-\d{4}-\d{3}[0-9X]/i);
 			let author_name = orcid_element.previousSibling.textContent.trim()
 			item.notes.push({note: "orcid:" + orcid[0] + ' | ' + author_name + ' | ' + "taken from website"});
 		}


### PR DESCRIPTION
Changes addressing  https://github.com/ubtue/DatenProbleme/issues/2216 somehow did not update on my branch, I was hesitant to use `git force pull` and instead copied the changes directly from the repository. 
Actual changes adressing this issue are in line 89 and 91, replacing `.replace()` with `.match()` to catch faulty orcid info such as `<a href="[https://orcid.org/https://orcid.org/0009-0005-2988-6671](view-source:https://orcid.org/https://orcid.org/0009-0005-2988-6671)"` in this case.