### PR TITLE
new translator ubtue_Brepols_new.js

### DIFF
--- a/ubtue_Brepols_new.js
+++ b/ubtue_Brepols_new.js
@@ -1,0 +1,111 @@
+{
+	"translatorID": "f0447d97-7566-4ec6-8150-6aa6c6652096",
+	"label": "ubtue_Brepols_new",
+	"creator": "Mara Spieß",
+	"target": "https://www.brepolsonline.net/content/journals/",
+	"minVersion": "5.0",
+	"maxVersion": "",
+	"priority": 100,
+	"inRepository": true,
+	"translatorType": 4,
+	"browserSupport": "gcsibv",
+	"lastUpdated": "2026-04-10 10:21:38"
+}
+
+/*
+    ***** BEGIN LICENSE BLOCK *****
+
+    Copyright © 2026 Universitätsbibliothek Tübingen
+
+    This file is part of Zotero.
+
+    Zotero is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    Zotero is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with Zotero. If not, see <http://www.gnu.org/licenses/>.
+
+    ***** END LICENSE BLOCK *****
+*/
+
+
+function detectWeb(doc, url) {
+	if (url.includes('/content/journals/10./')) {
+		return 'journalArticle';
+	}
+	else if (getSearchResults(doc, true)) {
+		return 'multiple';
+	}
+	return false;
+}
+
+function getSearchResults(doc, checkOnly) {
+	var items = {};
+	var found = false;
+	var rows = doc.querySelectorAll('li.articleInToc span.articleTitle');
+	for (let row of rows) {
+		let href = row.querySelector('a[href*="/journals/10."]');
+		let title = ZU.trimInternal(row.textContent);
+		if (!href || !title) continue;
+		if (checkOnly) return true;
+		found = true;
+		items[href] = title;
+	}
+	return found ? items : false;
+}
+
+async function doWeb(doc, url) {
+	if (detectWeb(doc, url) == 'multiple') {
+		let items = await Zotero.selectItems(getSearchResults(doc, false));
+		if (!items) return;
+		for (let url of Object.keys(items)) {
+			await scrape(await requestDocument(url));
+		}
+	}
+	else {
+		await scrape(doc, url);
+	}
+}
+
+async function scrape(doc, url = doc.location.href) {
+	let translator = Zotero.loadTranslator('web');
+	// Embedded Metadata
+	translator.setTranslator('951c027d-74ac-47d4-a107-9c3069ab7b48');
+	translator.setDocument(doc);
+	
+	translator.setHandler('itemDone', (_obj, item) => {
+
+		// Rezensionskennzeichnung
+		let articleType = doc.querySelector('span.document_type');
+		if (articleType && articleType.innerText.match(/book\s+review/i)) {
+			item.tags.push('RezensionstagPica');
+		}
+
+		// Abstractbereinigung
+		if (item.abstractNote) {
+			item.abstractNote = item.abstractNote.replace(/^abstract/i, '');
+		}
+
+		// Open Access Artikel
+		let openAccessIcon = doc.querySelector('h1.h2 abbr.access_icon_oa');
+		if (openAccessIcon) {
+			item.notes.push('LF:');
+		}
+		item.complete();
+	});
+
+	let em = await translator.getTranslatorObject();
+	await em.doWeb(doc, url);
+}
+
+/** BEGIN TEST CASES **/
+var testCases = [
+]
+/** END TEST CASES **/

--- a/ubtue_OpenEdition Journals.js
+++ b/ubtue_OpenEdition Journals.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-04-10 14:07:08"
+	"lastUpdated": "2026-04-13 12:08:06"
 }
 
 /*
@@ -59,19 +59,22 @@ function getSearchResults(doc) {
 function getOrcid(item, doc) {
     let authors = doc.getElementById('authors');
     if (authors) { 
-        let authorIDlist = authors.querySelector('ul.authorid-list');
-        if (authorIDlist) {
+        let authorIDlists = authors.querySelectorAll('ul.authorid-list'); 
+        authorIDlists.forEach(authorIDlist => {
             let authorOrcid = authorIDlist.querySelector('a[href*="https://orcid.org/"]');
             if (authorOrcid) {
-                let authorLink = authorIDlist.parentElement.querySelector('h3 a');
-				if (authorLink) {
-					let authorName = authorLink.textContent.trim();
-					if (authorName) {
-						item.notes.push('orcid: ' + authorOrcid.href + ' | ' + authorName + ' | taken from website');
-					}
-				}  
-            }                                                                    
-        }
+                let authorLink = authorIDlist.previousElementSibling;
+                if (authorLink && authorLink.tagName === 'H3') {
+                    let nameLink = authorLink.querySelector('a');
+                    if (nameLink) {
+                        let authorName = nameLink.textContent.trim();
+                        if (authorName) {
+                            item.notes.push('orcid: ' + authorOrcid.href + ' | ' + authorName + ' | taken from website');
+                        }
+                    }
+                }    
+            }
+        });
     }
 }
 

--- a/ubtue_OpenEdition Journals.js
+++ b/ubtue_OpenEdition Journals.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-03-27 14:54:25"
+	"lastUpdated": "2026-04-10 14:07:08"
 }
 
 /*
@@ -56,6 +56,25 @@ function getSearchResults(doc) {
 	return found ? items : false;
 }
 
+function getOrcid(item, doc) {
+    let authors = doc.getElementById('authors');
+    if (authors) { 
+        let authorIDlist = authors.querySelector('ul.authorid-list');
+        if (authorIDlist) {
+            let authorOrcid = authorIDlist.querySelector('a[href*="https://orcid.org/"]');
+            if (authorOrcid) {
+                let authorLink = authorIDlist.parentElement.querySelector('h3 a');
+				if (authorLink) {
+					let authorName = authorLink.textContent.trim();
+					if (authorName) {
+						item.notes.push('orcid: ' + authorOrcid.href + ' | ' + authorName + ' | taken from website');
+					}
+				}  
+            }                                                                    
+        }
+    }
+}
+
 function invokeEmbeddedMetadataTranslator(doc, url) {
 	let translator = Zotero.loadTranslator("web");
 	translator.setTranslator("951c027d-74ac-47d4-a107-9c3069ab7b48");
@@ -81,6 +100,7 @@ function invokeEmbeddedMetadataTranslator(doc, url) {
 				item.issue = issueAndVol[2];
 			}
 		}
+		getOrcid(item, doc);
 		//issue number as volume
 		if (item.issue && ['1972-2516', '0776-3824', '0335-5985', '1760-5776'].includes(item.ISSN)) {
 			item.volume = item.issue;

--- a/ubtue_Oxford Academic.js
+++ b/ubtue_Oxford Academic.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-04-09 10:38:24"
+	"lastUpdated": "2026-04-10 12:15:14"
 }
 
 /*
@@ -68,7 +68,7 @@ const JOURNAL_ISSN_MAP = new Map([
 function getISSNOrNotMapped(i) {
    let issn;
    if (i.publicationTitle) 
-       issn = JOURNAL_ISSN_MAP.get(i.publicationTitle.toLowerCase());
+	   issn = JOURNAL_ISSN_MAP.get(i.publicationTitle.toLowerCase());
    return issn ? issn : "ISSN not mapped";
 }
 
@@ -82,8 +82,8 @@ function invokeEmbeddedMetadataTranslator(doc, url) {
 		if (abstractText) i.abstractNote = abstractText;
 		var tagreview = ZU.xpathText(doc, '//*[(@id = "ContentTab")]//a');
 		if (tagreview) {
-			if (tagreview.match(/Reviews|Book Reviews/i)) delete i.abstractNote;
-			if (tagreview.match(/Reviews|Book Reviews/i)) i.tags.push('RezensionstagPica');
+			if (tagreview.match(/Reviews|Book Reviews?/i)) delete i.abstractNote;
+			if (tagreview.match(/Reviews|Book Reviews?/i)) i.tags.push('RezensionstagPica');
 		}
 		
 		if (ZU.xpathText(doc, '//i[@class="icon-availability_open"]/@title') != null) {

--- a/ubtue_Project MUSE.js
+++ b/ubtue_Project MUSE.js
@@ -9,7 +9,7 @@
 	"inRepository": true,
 	"translatorType": 4,
 	"browserSupport": "gcsibv",
-	"lastUpdated": "2026-03-27 15:22:35"
+	"lastUpdated": "2026-04-10 11:40:30"
 }
 
 /*
@@ -91,7 +91,7 @@ function getOrcids(doc, item) {
 		let author = webAuthor?.textContent?.trim()
 		let orcid = ZU.xpath(webAuthor, '//a[@class="orcid_link"]')?.[0]?.href?.replace(/.*(\d{4}-\d+-\d+-\d+x?)$/i, '$1');
 		if (author && orcid)
-		    item.notes.push({note: "orcid:" + orcid + ' | ' + author});
+			item.notes.push({note: "orcid:" + orcid + ' | ' + author});
 	}
 }
 
@@ -138,7 +138,7 @@ function scrape(doc) {
 			if (item.pages && item.pages.split('-').length > 1) {
 				if (item.pages.split('-')[0] == item.pages.split('-')[1]) item.pages = item.pages.split('-')[0];
 			}
-			if (ZU.xpathText(doc, '//div[@class="cell label"][contains(text(),"Open Access")]/following-sibling::div[contains(text(),"Yes")]')) {
+			if (ZU.xpathText(doc, '//*[@class="cell label"][contains(text(),"Open Access")]/following-sibling::*[contains(text(),"Yes")]')) {
 				item.notes.push('LF:');
 			}
 			if (!item.issue) {


### PR DESCRIPTION
The current translator (ubtue_Brepols) seems unfit for the current version of the website. Instead of retrofitting and possibly overcomplicating ubtue_Brepols, I decided on a new version to start from scratch. Website currently provides good quality metadata, that mostly doesn't necessitate any modifcations. 
Addresses https://github.com/ubtue/DatenProbleme/issues/2408